### PR TITLE
[WIP] Decompiler Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ out/
 securify.ipr
 securify.iws
 scripts/__pycache__
+/bin/

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ docker run -v $(pwd)/folder_with_solidity_files:/project securify
 This should allow Securify to run over Truffle project in which dependencies
 have already been installed (so run `npm install` before if need be).
 
+The indices of the lines matched are 0-based, meaning that a match to line `i`
+means that the `i+1`th line is matched. In particular, the first line has an
+index of 0.
+
 ### Output
 
 The output is a in JSON and gives the vulnerabilities found over the files

--- a/README.md
+++ b/README.md
@@ -103,6 +103,22 @@ The indices of the lines matched are 0-based, meaning that a match to line `i`
 means that the `i+1`th line is matched. In particular, the first line has an
 index of 0.
 
+
+### Travis
+
+You can add the following `.travis.yml` to your project to run Securify on new
+commits:
+```
+services:
+  - docker
+
+before_install:
+  - docker pull chainsecurity/securify
+
+script:
+- docker run -v $(pwd):/project chainsecurity/securify
+```
+
 ### Output
 
 The output is a in JSON and gives the vulnerabilities found over the files

--- a/docker_run_securify
+++ b/docker_run_securify
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -eu
-securify_cmd="java -Xmx16G -jar /securify_jar/securify.jar -co"
+memory="$(grep MemFree /proc/meminfo | awk '{print int($2 / 1024 / 1024)}')"
+securify_cmd="java -Xmx${memory}G -jar /securify_jar/securify.jar -co"
 cd / && python3 -m sec.scripts.pysolc /project /comp.json
 
 $securify_cmd /comp.json

--- a/scripts/install_solc.py
+++ b/scripts/install_solc.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from .pysolc import install_last_version
+from .pysolc import install_all_versions
 
 if __name__ == '__main__':
-    install_last_version()
+    install_all_versions()

--- a/src/main/java/ch/securify/Main.java
+++ b/src/main/java/ch/securify/Main.java
@@ -308,23 +308,24 @@ public class Main {
      */
     public static List<Instruction> decompileContract(byte[] binary) {
         List<Instruction> instructions;
-        try {
-            log.println("Attempt to decompile the contract with methods...");
-            instructions = Decompiler.decompile(binary, log);
-
-            log.println("Success. Inlining methods...");
-            instructions = MethodInliner.inline(instructions, log);
-        } catch (Exception e1) {
-            log.println(e1.getMessage());
-            log.println("Failed to decompile methods. Attempt to decompile the contract without identifying methods...");
+//        try {
+//            log.println("Attempt to decompile the contract with methods...");
+//            instructions = Decompiler.decompile(binary, log);
+//
+//            log.println("Success. Inlining methods...");
+//            instructions = MethodInliner.inline(instructions, log);
+//        } catch (Exception e1) {
+//            log.println(e1.getMessage());
+//            log.println("Failed to decompile methods. Attempt to decompile the contract without identifying methods...");
 
             try {
                 instructions = DecompilerFallback.decompile(binary, log);
             } catch (Exception e2) {
                 log.println("Decompilation failed.");
+                e2.printStackTrace();
                 throw e2;
             }
-        }
+//        }
 
         log.println("Propagating constants...");
         ConstantPropagation.propagate(instructions);

--- a/src/main/java/ch/securify/Main.java
+++ b/src/main/java/ch/securify/Main.java
@@ -308,15 +308,15 @@ public class Main {
      */
     public static List<Instruction> decompileContract(byte[] binary) {
         List<Instruction> instructions;
-//        try {
-//            log.println("Attempt to decompile the contract with methods...");
-//            instructions = Decompiler.decompile(binary, log);
-//
-//            log.println("Success. Inlining methods...");
-//            instructions = MethodInliner.inline(instructions, log);
-//        } catch (Exception e1) {
-//            log.println(e1.getMessage());
-//            log.println("Failed to decompile methods. Attempt to decompile the contract without identifying methods...");
+        try {
+            log.println("Attempt to decompile the contract with methods...");
+            instructions = Decompiler.decompile(binary, log);
+
+            log.println("Success. Inlining methods...");
+            instructions = MethodInliner.inline(instructions, log);
+        } catch (Exception e1) {
+            log.println(e1.getMessage());
+            log.println("Failed to decompile methods. Attempt to decompile the contract without identifying methods...");
 
             try {
                 instructions = DecompilerFallback.decompile(binary, log);
@@ -325,7 +325,7 @@ public class Main {
                 e2.printStackTrace();
                 throw e2;
             }
-//        }
+        }
 
         log.println("Propagating constants...");
         ConstantPropagation.propagate(instructions);

--- a/src/main/java/ch/securify/analysis/AbstractDataflow.java
+++ b/src/main/java/ch/securify/analysis/AbstractDataflow.java
@@ -456,7 +456,7 @@ public abstract class AbstractDataflow {
                     // tag the arguments to depend on user input (CallDataLoad)
                     createAssignTypeRule(instr, arg, CallDataLoad.class);
                 }
-            } else if (instr instanceof Call) {
+            } else if (instr instanceof Call || instr instanceof StaticCall) {
                 log("Type of " + instr.getOutput()[0] + " is Call");
                 createAssignTopRule(instr, instr.getOutput()[0]);
                 // assign the return value as an abstract type (to check later
@@ -543,7 +543,7 @@ public abstract class AbstractDataflow {
                 }
             }
 
-            if (instr instanceof Call) {
+            if (instr instanceof Call || instr instanceof StaticCall) {
                 createAssignVarRule(instr, instr.getOutput()[0], instr.getInput()[2]);
             }
 
@@ -570,6 +570,7 @@ public abstract class AbstractDataflow {
                     || instr instanceof SStore
                     || instr instanceof SLoad
                     || instr instanceof Call
+                    || instr instanceof StaticCall                    
                     || instr instanceof Sha3) {
                 continue;
             }

--- a/src/main/java/ch/securify/analysis/AbstractDataflow.java
+++ b/src/main/java/ch/securify/analysis/AbstractDataflow.java
@@ -468,6 +468,8 @@ public abstract class AbstractDataflow {
                 // TODO: double check whether to propagate the type of the
                 // argument to the output of blockhash
                 createAssignVarRule(instr, instr.getOutput()[0], instr.getInput()[0]);
+            } else if (instr instanceof ReturnDataCopy) {
+                // TODO: New memory-based rule here
             }
         }
     }

--- a/src/main/java/ch/securify/decompiler/ControlFlowDetector.java
+++ b/src/main/java/ch/securify/decompiler/ControlFlowDetector.java
@@ -221,6 +221,12 @@ public class ControlFlowDetector {
 				richBranches.put(pc, BRANCH_EXIT);
 				return;
 			}
+			else if (opcode == OpCodes.REVERT) {
+				// end of execution
+				addExecutionBranch(branchStartOffset, RichBranch.c(pc, evmStack));
+				richBranches.put(pc, BRANCH_ERROR);
+				return;
+			}			
 			else if (opcode == OpCodes.SELFDESTRUCT) {
 				// end of execution
 				addExecutionBranch(branchStartOffset, RichBranch.c(pc, evmStack));

--- a/src/main/java/ch/securify/decompiler/Destacker.java
+++ b/src/main/java/ch/securify/decompiler/Destacker.java
@@ -270,7 +270,7 @@ public class Destacker {
 				// continue on current branch
 				continue;
 			}
-			else if (opcode == OpCodes.STOP || opcode == OpCodes.RETURN || opcode == OpCodes.SELFDESTRUCT || OpCodes.isInvalid(opcode)) {
+			else if (opcode == OpCodes.STOP || opcode == OpCodes.RETURN || opcode == OpCodes.REVERT || opcode == OpCodes.SELFDESTRUCT || OpCodes.isInvalid(opcode)) {
 				// end of execution
 				return;
 			}

--- a/src/main/java/ch/securify/decompiler/DestackerFallback.java
+++ b/src/main/java/ch/securify/decompiler/DestackerFallback.java
@@ -158,9 +158,8 @@ public class DestackerFallback {
 
 			log.print("[DS] decompiling @" + toHex(pc) + " " + OpCodes.getOpName(rawInstructions[pc].opcode));
 
-/*			
 			// Hotfix
-			// TODO: Fix properly
+			// TODO: Fix properly, rollback further
 			if(instructionFactory.stackTooSmall(rawInstruction, evmStack) != -1) {
 				// Securify took an unforeseen path through the executable
 				// This path doesn't work, others might, rollback
@@ -182,7 +181,6 @@ public class DestackerFallback {
 				//decompile(branchStartOffset, rollBackStack);
 				return;				
 			}
-*/
 			
 			instructions[pc] = instructionFactory.createAndApply(rawInstruction, evmStack);
 

--- a/src/main/java/ch/securify/decompiler/DestackerFallback.java
+++ b/src/main/java/ch/securify/decompiler/DestackerFallback.java
@@ -244,7 +244,7 @@ public class DestackerFallback {
 				// continue on current branch
 				continue;
 			}
-			else if (opcode == OpCodes.STOP || opcode == OpCodes.RETURN || opcode == OpCodes.SELFDESTRUCT || OpCodes.isInvalid(opcode)) {
+			else if (opcode == OpCodes.STOP || opcode == OpCodes.RETURN || opcode == OpCodes.REVERT || opcode == OpCodes.SELFDESTRUCT || OpCodes.isInvalid(opcode)) {
 				// end of execution
 				return;
 			}

--- a/src/main/java/ch/securify/decompiler/DestackerFallback.java
+++ b/src/main/java/ch/securify/decompiler/DestackerFallback.java
@@ -158,7 +158,7 @@ public class DestackerFallback {
 
 			log.print("[DS] decompiling @" + toHex(pc) + " " + OpCodes.getOpName(rawInstructions[pc].opcode));
 
-			
+/*			
 			// Hotfix
 			// TODO: Fix properly
 			if(instructionFactory.stackTooSmall(rawInstruction, evmStack) != -1) {
@@ -182,6 +182,7 @@ public class DestackerFallback {
 				//decompile(branchStartOffset, rollBackStack);
 				return;				
 			}
+*/
 			
 			instructions[pc] = instructionFactory.createAndApply(rawInstruction, evmStack);
 

--- a/src/main/java/ch/securify/decompiler/InstructionFactory.java
+++ b/src/main/java/ch/securify/decompiler/InstructionFactory.java
@@ -182,6 +182,8 @@ public class InstructionFactory {
 			case OpCodes.CALLCODE: return new CallCode();
 			case OpCodes.RETURN: return new Return();
 			case OpCodes.DELEGATECALL: return new DelegateCall();
+			case OpCodes.STATICCALL: return new StaticCall();
+			case OpCodes.REVERT: return new Revert();			
 			case OpCodes.SELFDESTRUCT: return new SelfDestruct();
 		}
 		int pos;
@@ -269,7 +271,9 @@ public class InstructionFactory {
 			case OpCodes.CALL: return Call.class.getSimpleName();
 			case OpCodes.CALLCODE: return CallCode.class.getSimpleName();
 			case OpCodes.RETURN: return Return.class.getSimpleName();
+			case OpCodes.REVERT: return Revert.class.getSimpleName();
 			case OpCodes.DELEGATECALL: return DelegateCall.class.getSimpleName();
+			case OpCodes.STATICCALL: return StaticCall.class.getSimpleName();			
 			case OpCodes.SELFDESTRUCT: return SelfDestruct.class.getSimpleName();
 
 		}

--- a/src/main/java/ch/securify/decompiler/InstructionFactory.java
+++ b/src/main/java/ch/securify/decompiler/InstructionFactory.java
@@ -64,6 +64,20 @@ public class InstructionFactory {
 		return labelResolver;
 	}
 
+    // Check if the current stack is too small for the next instruction
+    // Return size difference or -1 is fine
+	public int stackTooSmall(RawInstruction rawInstruction, Stack<Variable> stack) {
+		if(OpCodes.getPopCount(rawInstruction.opcode) > stack.size()) {
+			return OpCodes.getPopCount(rawInstruction.opcode) - stack.size();
+		}
+		// Check for dups
+		int dupNum = OpCodes.isDup(rawInstruction.opcode);
+		if(dupNum != -1 && dupNum + 1 > stack.size()) {
+			return dupNum+1-stack.size();
+		}
+		
+		return -1;
+	}
 
 	/**
 	 * Create an instruction instance for a given raw EVM instruction and apply its effects on the stack.
@@ -154,6 +168,8 @@ public class InstructionFactory {
 			case OpCodes.GASPRICE: return new GasPrice();
 			case OpCodes.EXTCODESIZE: return new ExtCodeSize();
 			case OpCodes.EXTCODECOPY: return new ExtCodeCopy();
+			case OpCodes.RETURNDATASIZE: return new ReturnDataSize();
+			case OpCodes.RETURNDATACOPY: return new ReturnDataCopy();			
 			case OpCodes.BLOCKHASH: return new BlockHash();
 			case OpCodes.COINBASE: return new Coinbase();
 			case OpCodes.TIMESTAMP: return new BlockTimestamp();
@@ -184,6 +200,7 @@ public class InstructionFactory {
 			case OpCodes.DELEGATECALL: return new DelegateCall();
 			case OpCodes.STATICCALL: return new StaticCall();
 			case OpCodes.REVERT: return new Revert();			
+			case OpCodes.INVALID: return new Invalid();
 			case OpCodes.SELFDESTRUCT: return new SelfDestruct();
 		}
 		int pos;
@@ -244,6 +261,8 @@ public class InstructionFactory {
 			case OpCodes.GASPRICE: return GasPrice.class.getSimpleName();
 			case OpCodes.EXTCODESIZE: return ExtCodeSize.class.getSimpleName();
 			case OpCodes.EXTCODECOPY: return ExtCodeCopy.class.getSimpleName();
+			case OpCodes.RETURNDATASIZE: return ReturnDataSize.class.getSimpleName();
+			case OpCodes.RETURNDATACOPY: return ReturnDataCopy.class.getSimpleName();					
 			case OpCodes.BLOCKHASH: return BlockHash.class.getSimpleName();
 			case OpCodes.COINBASE: return Coinbase.class.getSimpleName();
 			case OpCodes.TIMESTAMP: return BlockTimestamp.class.getSimpleName();
@@ -274,6 +293,7 @@ public class InstructionFactory {
 			case OpCodes.REVERT: return Revert.class.getSimpleName();
 			case OpCodes.DELEGATECALL: return DelegateCall.class.getSimpleName();
 			case OpCodes.STATICCALL: return StaticCall.class.getSimpleName();			
+			case OpCodes.INVALID: return Invalid.class.getSimpleName();
 			case OpCodes.SELFDESTRUCT: return SelfDestruct.class.getSimpleName();
 
 		}

--- a/src/main/java/ch/securify/decompiler/MethodDetector.java
+++ b/src/main/java/ch/securify/decompiler/MethodDetector.java
@@ -324,7 +324,7 @@ public class MethodDetector {
 				// continue on current branch
 				continue;
 			}
-			else if (opcode == OpCodes.STOP || opcode == OpCodes.RETURN || opcode == OpCodes.SELFDESTRUCT || OpCodes.isInvalid(opcode)) {
+			else if (opcode == OpCodes.STOP || opcode == OpCodes.RETURN || opcode == OpCodes.REVERT || opcode == OpCodes.SELFDESTRUCT || OpCodes.isInvalid(opcode)) {
 				// end of execution
 				return;
 			}

--- a/src/main/java/ch/securify/decompiler/evm/OpCodes.java
+++ b/src/main/java/ch/securify/decompiler/evm/OpCodes.java
@@ -67,7 +67,9 @@ public class OpCodes {
 	public static final int GASPRICE = 0x3a;
 	public static final int EXTCODESIZE = 0x3b;
 	public static final int EXTCODECOPY = 0x3c;
-
+	public static final int RETURNDATASIZE = 0x3d;
+	public static final int RETURNDATACOPY = 0x3e;
+	
 	// Block Information
 	public static final int BLOCKHASH = 0x40;
 	public static final int COINBASE = 0x41;
@@ -168,7 +170,9 @@ public class OpCodes {
 	public static final int DELEGATECALL = 0xf4;
 	public static final int STATICCALL = 0xf5;	
 	public static final int REVERT = 0xfd;
+	public static final int INVALID = 0xfe;	
 	public static final int SELFDESTRUCT = 0xff;
+
 
 	/**
 	 * Get the name of the operation.
@@ -202,7 +206,7 @@ public class OpCodes {
 	 * @return
 	 */
 	public static boolean isInvalid(int opcode) {
-		return "INVALID".equals(getOpName(opcode));
+		return "INVALID".equals(getOpName(opcode)) || opcode == INVALID;
 	}
 
 
@@ -259,6 +263,8 @@ public class OpCodes {
 			case GASPRICE: return 0;
 			case EXTCODESIZE: return 1;
 			case EXTCODECOPY: return 4;
+			case RETURNDATASIZE: return 0;
+			case RETURNDATACOPY: return 3;			
 			case BLOCKHASH: return 1;
 			case COINBASE: return 0;
 			case TIMESTAMP: return 0;
@@ -288,7 +294,8 @@ public class OpCodes {
 			case RETURN: return 2;
 			case DELEGATECALL: return 6;
 			case STATICCALL: return 6;
-			case REVERT: return 2;			
+			case REVERT: return 2;		
+			case INVALID: return 0;			
 			case SELFDESTRUCT: return 1;
 		}
 		if (isPush(opcode) > -1) {
@@ -348,6 +355,8 @@ public class OpCodes {
 			case GASPRICE: return 1;
 			case EXTCODESIZE: return 1;
 			case EXTCODECOPY: return 0;
+			case RETURNDATASIZE: return 1;
+			case RETURNDATACOPY: return 0;
 			case BLOCKHASH: return 1;
 			case COINBASE: return 1;
 			case TIMESTAMP: return 1;
@@ -378,6 +387,7 @@ public class OpCodes {
 			case DELEGATECALL: return 1;
 			case STATICCALL: return 1;			
 			case REVERT: return 0;			
+			case INVALID: return 0;
 			case SELFDESTRUCT: return 0;
 		}
 		if (isPush(opcode) > -1) {

--- a/src/main/java/ch/securify/decompiler/evm/OpCodes.java
+++ b/src/main/java/ch/securify/decompiler/evm/OpCodes.java
@@ -166,8 +166,9 @@ public class OpCodes {
 	public static final int CALLCODE = 0xf2;
 	public static final int RETURN = 0xf3;
 	public static final int DELEGATECALL = 0xf4;
+	public static final int STATICCALL = 0xf5;	
+	public static final int REVERT = 0xfd;
 	public static final int SELFDESTRUCT = 0xff;
-
 
 	/**
 	 * Get the name of the operation.
@@ -286,6 +287,8 @@ public class OpCodes {
 			case CALLCODE: return 7;
 			case RETURN: return 2;
 			case DELEGATECALL: return 6;
+			case STATICCALL: return 6;
+			case REVERT: return 2;			
 			case SELFDESTRUCT: return 1;
 		}
 		if (isPush(opcode) > -1) {
@@ -373,6 +376,8 @@ public class OpCodes {
 			case CALLCODE: return 1;
 			case RETURN: return 0;
 			case DELEGATECALL: return 1;
+			case STATICCALL: return 1;			
+			case REVERT: return 0;			
 			case SELFDESTRUCT: return 0;
 		}
 		if (isPush(opcode) > -1) {

--- a/src/main/java/ch/securify/decompiler/evm/OpCodes.java
+++ b/src/main/java/ch/securify/decompiler/evm/OpCodes.java
@@ -168,7 +168,7 @@ public class OpCodes {
 	public static final int CALLCODE = 0xf2;
 	public static final int RETURN = 0xf3;
 	public static final int DELEGATECALL = 0xf4;
-	public static final int STATICCALL = 0xf5;	
+	public static final int STATICCALL = 0xfa;	
 	public static final int REVERT = 0xfd;
 	public static final int INVALID = 0xfe;	
 	public static final int SELFDESTRUCT = 0xff;

--- a/src/main/java/ch/securify/decompiler/instructions/ReturnDataCopy.java
+++ b/src/main/java/ch/securify/decompiler/instructions/ReturnDataCopy.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright 2018 Secure, Reliable, and Intelligent Systems Lab, ETH Zurich
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+
+package ch.securify.decompiler.instructions;
+
+public class ReturnDataCopy extends Instruction {
+
+	@Override
+	public String getStringRepresentation() {
+		return "returndatacopy(memoffset: " + getInput()[0] + ", returndataoffset: " + getInput()[1] + ", length: " + getInput()[2] + ")";
+	}
+
+}

--- a/src/main/java/ch/securify/decompiler/instructions/ReturnDataCopy.java
+++ b/src/main/java/ch/securify/decompiler/instructions/ReturnDataCopy.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2018 Secure, Reliable, and Intelligent Systems Lab, ETH Zurich
+ *  Copyright 2018 ChainSecurity AG 
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/ch/securify/decompiler/instructions/ReturnDataSize.java
+++ b/src/main/java/ch/securify/decompiler/instructions/ReturnDataSize.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2018 Secure, Reliable, and Intelligent Systems Lab, ETH Zurich
+ *  Copyright 2018 ChainSecurity AG 
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/ch/securify/decompiler/instructions/ReturnDataSize.java
+++ b/src/main/java/ch/securify/decompiler/instructions/ReturnDataSize.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright 2018 Secure, Reliable, and Intelligent Systems Lab, ETH Zurich
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+
+package ch.securify.decompiler.instructions;
+
+public class ReturnDataSize extends Instruction {
+
+	@Override
+	public String getStringRepresentation() {
+		return "returndatasize()";
+	}
+
+}

--- a/src/main/java/ch/securify/decompiler/instructions/Revert.java
+++ b/src/main/java/ch/securify/decompiler/instructions/Revert.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright 2018 Secure, Reliable, and Intelligent Systems Lab, ETH Zurich
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+
+package ch.securify.decompiler.instructions;
+
+public class Revert extends Instruction {
+
+	@Override
+	public String getStringRepresentation() {
+		return "revert(memoffset: " + getInput()[0] + ", length: " + getInput()[1] + ")";
+	}
+
+}

--- a/src/main/java/ch/securify/decompiler/instructions/Revert.java
+++ b/src/main/java/ch/securify/decompiler/instructions/Revert.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2018 Secure, Reliable, and Intelligent Systems Lab, ETH Zurich
+ *  Copyright 2018 ChainSecurity AG 
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/ch/securify/decompiler/instructions/StaticCall.java
+++ b/src/main/java/ch/securify/decompiler/instructions/StaticCall.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright 2018 Secure, Reliable, and Intelligent Systems Lab, ETH Zurich
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+
+package ch.securify.decompiler.instructions;
+
+import ch.securify.decompiler.Variable;
+import ch.securify.utils.BigIntUtil;
+
+import java.math.BigInteger;
+
+public class StaticCall extends Instruction implements _TypeInstruction {
+
+	@Override
+	public String getStringRepresentation() {
+		return getOutput()[0] + " = staticcall(gas: " + getInput()[0] + ", to_addr: " + getInput()[1] + ", " +
+				"in_offset: " + getInput()[2] + ", in_size: " + getInput()[3] + ", " +
+				"out_offset: " + getInput()[4] + ", out_size: " + getInput()[5] + ")";
+	}
+
+	public boolean isBuiltInContractCall() {
+		Variable toAddrVar = getInput()[1];
+		if (toAddrVar.hasConstantValue()) {
+			BigInteger toAddr = BigIntUtil.fromInt256(toAddrVar.getConstantValue());
+			if (toAddr.equals(BigInteger.valueOf(1)) || toAddr.equals(BigInteger.valueOf(2)) ||
+					toAddr.equals(BigInteger.valueOf(3)) || toAddr.equals(BigInteger.valueOf(4))) {
+				// is call to built-in contract
+				return true;
+			}
+		}
+		return false;
+	}
+
+}

--- a/src/main/java/ch/securify/decompiler/instructions/StaticCall.java
+++ b/src/main/java/ch/securify/decompiler/instructions/StaticCall.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2018 Secure, Reliable, and Intelligent Systems Lab, ETH Zurich
+ *  Copyright 2018 ChainSecurity AG 
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/ch/securify/utils/Pair.java
+++ b/src/main/java/ch/securify/utils/Pair.java
@@ -18,6 +18,8 @@
 
 package ch.securify.utils;
 
+import java.util.Objects;
+
 public class Pair<F,S> {
     public F first;
     public S second;
@@ -41,5 +43,16 @@ public class Pair<F,S> {
 
     public S getSecond() {
         return second;
+    }
+    
+    @Override
+    public boolean equals(Object obj) {
+    	Pair<F, S> other = (Pair<F, S>) obj;
+    	return getFirst().equals(other.getFirst()) && getSecond().equals(other.getSecond()); 
+    }
+    
+    @Override
+    public int hashCode() {
+    	return Objects.hash(getFirst(), getSecond());
     }
 }


### PR DESCRIPTION
* Adding additional EVM instructions to allow better decompilation (Revert, Returndatasize, Returndatacopy, Staticcall, Invalid)
* Hotfixing a bug that causes the intermediate representation to fail when a conditional jump is leading to two stack merges 
* Hotfixing another bug that causes the decompilation to crash in case of unbalanced stacks. Independently verified the jumps and the stack growth. They seem correct. A proper fix requires an slight adaptation in the abstraction.

Here is a breaking example for the first issue:
https://gist.github.com/ritzdorf/7aaa2f59a3be273d1aab9ee4d929219b
This should work now with the hotfix.

Generally, a lot more testing is needed.