### PR TITLE
Decompiler jumpi Stack Merge Bug

### DIFF
--- a/src/main/java/ch/securify/utils/Pair.java
+++ b/src/main/java/ch/securify/utils/Pair.java
@@ -20,20 +20,12 @@ package ch.securify.utils;
 
 import java.util.Objects;
 
-public class Pair<F,S> {
-    public F first;
-    public S second;
+public class Pair<F, S> {
+    final private F first;
+    final private S second;
 
     public Pair(F first, S second) {
         this.first = first;
-        this.second = second;
-    }
-
-    public void setFirst(F first) {
-        this.first = first;
-    }
-
-    public void setSecond(S second) {
         this.second = second;
     }
 
@@ -44,15 +36,15 @@ public class Pair<F,S> {
     public S getSecond() {
         return second;
     }
-    
+
     @Override
     public boolean equals(Object obj) {
-    	Pair<F, S> other = (Pair<F, S>) obj;
-    	return getFirst().equals(other.getFirst()) && getSecond().equals(other.getSecond()); 
+        Pair<F, S> other = (Pair<F, S>) obj;
+        return getFirst().equals(other.getFirst()) && getSecond().equals(other.getSecond());
     }
-    
+
     @Override
     public int hashCode() {
-    	return Objects.hash(getFirst(), getSecond());
+        return Objects.hash(first, second);
     }
 }

--- a/src/main/java/ch/securify/utils/Pair.java
+++ b/src/main/java/ch/securify/utils/Pair.java
@@ -18,6 +18,8 @@
 
 package ch.securify.utils;
 
+import java.util.Objects;
+
 public class Pair<F,S> {
     public F first;
     public S second;
@@ -41,5 +43,16 @@ public class Pair<F,S> {
 
     public S getSecond() {
         return second;
+    }
+    
+    @Override
+    public boolean equals(Object obj) {
+    	Pair<F, S> other = (Pair<F, S>) obj;
+    	return getFirst().equals(other.getFirst()) && getSecond().equals(other.getSecond()); 
+    }
+    
+    @Override
+    public int hashCode() {
+    	return Objects.hash(getFirst(), getSecond());
     }
 }


### PR DESCRIPTION
Fixes failing decompilation on the following example:
https://gist.github.com/ritzdorf/7aaa2f59a3be273d1aab9ee4d929219b

Problem was:
* A `jumpi` leading to two separate stack merges was not correctly decompiled

Fix:
* Introduce separate merging for true and false branch.