### PR TITLE
Progress information

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,14 +103,15 @@ docker run -v $(pwd)/folder_with_solidity_files:/project securify
 Adding a `--truffle` flag should allow Securify to run over Truffle project in
 which dependencies have already been installed (so run `npm install` before if
 need be). Without this flag, the project is compiled using `solc`. Add a `-h`
-to obtain the full list of options.
+to obtain the full list of options. In particular, if the user wants to receive
+compilation information from Truffle, he should add the `-v` flag.
 
-The indices of the lines matched are 0-based, meaning that a match to line `i`
-means that the `i+1`th line is matched. In particular, the first line has an
-index of 0.
-
-Alternatively, add the `--pretty` flag in order to get clang style output rather
-than JSON based output.
+If one wants to receive JSON output, the docker supports a `--json` flag that
+will suppress the pretty output and return JSON instead. Make sure to add the
+`-q` flag if no progress information should be displayed, hence resulting in
+pure JSON output. The indices of the lines matched are 0-based, meaning that
+a match to line `i` means that the `i+1`th line is matched. In particular, the
+first line has an index of 0.
 
 
 ### Travis
@@ -133,8 +134,10 @@ have already been installed (so run `npm install` before if need be).
 
 ### Output
 
-The output is a in JSON and gives the vulnerabilities found over the files
-analyzed and the corresponding line numbers.
+The output loosely follows the clang style. Only warnings and vulnerabilities
+are reported. If one wishes to also get the compliance information, please use
+the `--json` flag in the docker, or `-co` flag on the Java executable to get
+all analysis information in JSON format.
 
 ## Contributing
 

--- a/docker_run_securify.py
+++ b/docker_run_securify.py
@@ -17,6 +17,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import sys
+
 from scripts import controller
 
 if __name__ == "__main__":

--- a/scripts/controller.py
+++ b/scripts/controller.py
@@ -35,9 +35,9 @@ class Controller:
         self._parser.add_argument('-p', '--project',
                                   action="store", help="the project root",
                                   required=True)
-        self._parser.add_argument('--pretty',
+        self._parser.add_argument('--json',
                                   action="store_true",
-                                  help="provide clang style output instead of standard JSON")
+                                  help="provide JSON output")
         verbosity_group = self._parser.add_mutually_exclusive_group()
         verbosity_group.add_argument('-v', '--verbose',
                                      action="store_true",
@@ -49,9 +49,9 @@ class Controller:
         self.args = self._parser.parse_args()
 
         if self.args.truffle:
-            self._project = truffle_project.TruffleProject(self.args.project, self.args.pretty)
+            self._project = truffle_project.TruffleProject(self.args.project, self.args.json)
         else:
-            self._project = solc_project.SolcProject(self.args.project, self.args.pretty)
+            self._project = solc_project.SolcProject(self.args.project, self.args.json)
 
         if self.args.verbose:
             utils.set_logger_level("info")

--- a/scripts/controller.py
+++ b/scripts/controller.py
@@ -19,10 +19,10 @@ limitations under the License.
 """
 
 import argparse
+import logging
 
 from . import solc_project
 from . import truffle_project
-from . import utils
 
 
 class Controller:
@@ -49,16 +49,20 @@ class Controller:
         self.args = self._parser.parse_args()
 
         if self.args.truffle:
-            self._project = truffle_project.TruffleProject(self.args.project, self.args)
+            self._project = truffle_project.TruffleProject(
+                self.args.project, self.args)
         else:
-            self._project = solc_project.SolcProject(self.args.project, self.args)
+            self._project = solc_project.SolcProject(
+                self.args.project, self.args)
+
+        logging.basicConfig(format="%(message)s")
 
         if self.args.verbose:
-            utils.set_logger_level("info")
+            logging.basicConfig(level=logging.DEBUG)
         elif self.args.quiet:
-            utils.set_logger_level("error")
+            logging.basicConfig(level=logging.WARNING)
         else:
-            utils.set_logger_level("warning")
+            logging.basicConfig(level=logging.INFO)
 
     def compile_and_report(self):
         """Executes securify and returns violations and warnings.

--- a/scripts/controller.py
+++ b/scripts/controller.py
@@ -28,10 +28,10 @@ from . import utils
 class Controller:
     def __init__(self):
         """Initialise the controller. This sets up the command line argument parsing etc."""
-        self._parser = argparse.ArgumentParser(description='Run securify.')
+        self._parser = argparse.ArgumentParser(description='Run Securify.')
         self._parser.add_argument('-t', '--truffle',
                                   action="store_true",
-                                  help="use truffle project as base")
+                                  help="use Truffle project as base")
         self._parser.add_argument('-p', '--project',
                                   action="store", help="the project root",
                                   required=True)

--- a/scripts/controller.py
+++ b/scripts/controller.py
@@ -26,8 +26,10 @@ from . import truffle_project
 
 
 class Controller:
+    """Handles CLI arguments.
+    """
+
     def __init__(self):
-        """Initialise the controller. This sets up the command line argument parsing etc."""
         self._parser = argparse.ArgumentParser(description='Run Securify.')
         self._parser.add_argument('-t', '--truffle',
                                   action="store_true",

--- a/scripts/controller.py
+++ b/scripts/controller.py
@@ -37,7 +37,7 @@ class Controller:
                                   required=True)
         self._parser.add_argument('--json',
                                   action="store_true",
-                                  help="provide JSON output")
+                                  help="provide JSON output to console")
         verbosity_group = self._parser.add_mutually_exclusive_group()
         verbosity_group.add_argument('-v', '--verbose',
                                      action="store_true",
@@ -49,9 +49,9 @@ class Controller:
         self.args = self._parser.parse_args()
 
         if self.args.truffle:
-            self._project = truffle_project.TruffleProject(self.args.project, self.args.json)
+            self._project = truffle_project.TruffleProject(self.args.project, self.args)
         else:
-            self._project = solc_project.SolcProject(self.args.project, self.args.json)
+            self._project = solc_project.SolcProject(self.args.project, self.args)
 
         if self.args.verbose:
             utils.set_logger_level("info")

--- a/scripts/project.py
+++ b/scripts/project.py
@@ -47,11 +47,11 @@ class Project(metaclass=abc.ABCMeta):
         with tempfile.TemporaryDirectory() as d:
             tmpdir = pathlib.Path(d)
 
-            logging.warning("Compiling project")
+            logging.info("Compiling project")
             compilation_output = tmpdir / "comp.json"
             self.compile_(compilation_output)
 
-            logging.warning("Running Securify")
+            logging.info("Running Securify")
             securify_target_output = tmpdir / "securify_res.json"
             self.run_securify(compilation_output, securify_target_output)
 
@@ -72,10 +72,9 @@ class Project(metaclass=abc.ABCMeta):
 
         try:
             subprocess.run(cmd, check=True, universal_newlines=True)
-        except CalledProcessError as e:
+        except subprocess.CalledProcessError as e:
             logging.error("Error running Securify")
             utils.handle_process_output_and_exit(e)
-
 
     @abc.abstractmethod
     def compile_(self, compilation_output):

--- a/scripts/project.py
+++ b/scripts/project.py
@@ -18,12 +18,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import sys
 import abc
 import json
 import logging
-import subprocess
 import pathlib
+import subprocess
 import tempfile
 
 import psutil
@@ -35,10 +34,10 @@ class Project(metaclass=abc.ABCMeta):
     """
     securify_jar = pathlib.Path("build/libs/securify-0.1.jar")
 
-    def __init__(self, project_root, clargs):
+    def __init__(self, project_root, args):
         """Sets the project root."""
         self.project_root = pathlib.Path(project_root)
-        self.clargs = clargs
+        self.args = args
 
     def execute(self):
         """Execute the project. This includes compilation and reporting.
@@ -64,16 +63,15 @@ class Project(metaclass=abc.ABCMeta):
         cmd = ["java", f"-Xmx{memory}G", "-jar", str(self.securify_jar),
                "-co", compilation_output,
                "-o", securify_target_output]
-        if self.clargs.json:
+        if self.args.json:
             cmd += ["--json"]
-        if self.clargs.verbose:
+        if self.args.verbose:
             cmd += ["-v"]
-        if self.clargs.quiet:
+        if self.args.quiet:
             cmd += ["-q"]
 
         try:
-            subprocess.run(cmd, check=True, stdout=sys.stdout,
-                           stderr=sys.stderr, universal_newlines=True)
+            subprocess.run(cmd, check=True, universal_newlines=True)
         except CalledProcessError as e:
             logging.error("Error running Securify")
             utils.handle_process_output_and_exit(e)

--- a/scripts/project.py
+++ b/scripts/project.py
@@ -75,6 +75,7 @@ class Project(metaclass=abc.ABCMeta):
             subprocess.run(cmd, check=True, stdout=sys.stdout,
                            stderr=sys.stderr, universal_newlines=True)
         except CalledProcessError as e:
+            logging.error("Error running Securify")
             utils.handle_process_output_and_exit(e)
 
 

--- a/scripts/project.py
+++ b/scripts/project.py
@@ -28,6 +28,21 @@ import psutil
 from . import utils
 
 
+def report(securify_target_output):
+    """Report findings.
+
+    This function returns 0 if no violations are found, and 1 otherwise.
+    """
+    with open(securify_target_output) as file:
+        json_report = json.load(file)
+
+    for contract in json_report.values():
+        for pattern in contract["results"].values():
+            if pattern["violations"]:
+                return 1
+    return 0
+
+
 class Project(metaclass=abc.ABCMeta):
     """Abstract class implemented by projects using compilation and reporting.
     """
@@ -55,7 +70,7 @@ class Project(metaclass=abc.ABCMeta):
             securify_target_output = tmpdir / "securify_res.json"
             self.run_securify(compilation_output, securify_target_output)
 
-            return self.report(securify_target_output)
+            return report(securify_target_output)
 
     def run_securify(self, compilation_output, securify_target_output):
         """Runs the securify command.
@@ -79,19 +94,6 @@ class Project(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def compile_(self, compilation_output):
-        """Compile the project."""
-        pass
-
-    def report(self, securify_target_output):
-        """Report findings.
-
-        This function returns 0 if no violations are found, and 1 otherwise.
+        """Compile the project.
         """
-        with open(securify_target_output) as file:
-            json_report = json.load(file)
-
-        for contract in json_report.values():
-            for pattern in contract["results"].values():
-                if pattern["violations"]:
-                    return 1
-        return 0
+        pass

--- a/scripts/project.py
+++ b/scripts/project.py
@@ -32,10 +32,10 @@ class Project(metaclass=abc.ABCMeta):
     """
     securify_jar = pathlib.Path("build/libs/securify-0.1.jar")
 
-    def __init__(self, project_root, pretty_output):
+    def __init__(self, project_root, json_output):
         """Sets the project root."""
         self.project_root = pathlib.Path(project_root)
-        self.pretty_output = pretty_output
+        self.json_output = json_output
 
     def execute(self):
         """Execute the project. This includes compilation and reporting.
@@ -61,8 +61,8 @@ class Project(metaclass=abc.ABCMeta):
         cmd = ["java", f"-Xmx{memory}G", "-jar", str(self.securify_jar),
                "-co", compilation_output,
                "-o", securify_target_output]
-        if self.pretty_output:
-            cmd += ["--pretty"]
+        if self.json_output:
+            cmd += ["--no-output"]
 
         utils.run_cmd(cmd)
 
@@ -79,7 +79,7 @@ class Project(metaclass=abc.ABCMeta):
         with open(securify_target_output) as file:
             json_report = json.load(file)
 
-        if not self.pretty_output:
+        if self.json_output:
             print(json.dumps(json_report, indent=4))
 
         for contract in json_report.values():

--- a/scripts/project.py
+++ b/scripts/project.py
@@ -17,7 +17,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-
 import abc
 import json
 import logging
@@ -35,12 +34,13 @@ class Project(metaclass=abc.ABCMeta):
     securify_jar = pathlib.Path("build/libs/securify-0.1.jar")
 
     def __init__(self, project_root, args):
-        """Sets the project root."""
+        """Sets the project root.
+        """
         self.project_root = pathlib.Path(project_root)
         self.args = args
 
     def execute(self):
-        """Execute the project. This includes compilation and reporting.
+        """Executes the project. This includes compilation and reporting.
 
         This function returns 0 if no violations are found, and 1 otherwise.
         """
@@ -58,7 +58,8 @@ class Project(metaclass=abc.ABCMeta):
             return self.report(securify_target_output)
 
     def run_securify(self, compilation_output, securify_target_output):
-        """Runs the securify command."""
+        """Runs the securify command.
+        """
         memory = psutil.virtual_memory().available // 1024 ** 3
         cmd = ["java", f"-Xmx{memory}G", "-jar", str(self.securify_jar),
                "-co", compilation_output,

--- a/scripts/solc_project.py
+++ b/scripts/solc_project.py
@@ -30,17 +30,20 @@ from . import project, utils
 
 
 def _get_binary(version):
-    """Returns the binary for some version of solc."""
+    """Returns the binary for some version of solc.
+    """
     binary = os.path.join(Path.home(), f'.py-solc/solc-v{version}/bin/solc')
     assert os.path.exists(binary), 'solc binary not found'
     return binary
 
 
 class SolcProject(project.Project):
-    """A project that uses the `solc` compiler."""
+    """A project that uses the `solc` compiler.
+    """
 
     def compile_(self, compilation_output):
-        """Compile the project and dump the output to an intermediate file."""
+        """Compile the project and dump the output to an intermediate file.
+        """
         sources = self._get_sol_files()
 
         if not sources:
@@ -52,7 +55,8 @@ class SolcProject(project.Project):
             json.dump(comp_output, fs)
 
     def _get_sol_files(self):
-        """Returns the solidity files contained in the project root."""
+        """Returns the solidity files contained in the project root.
+        """
         return [os.path.join(p, f) for p, _, fs in os.walk(self.project_root) for f in fs if
                 f.endswith('.sol') and
                 'node_modules' not in p and
@@ -60,7 +64,8 @@ class SolcProject(project.Project):
                 not p.endswith('/test')]
 
     def _compile_solfiles(self, files, solc_version=None, output_values=utils.OUTPUT_VALUES):
-        """Compiles the files using the solc compiler."""
+        """Compiles the files using the solc compiler.
+        """
         node_modules_dir = utils.find_node_modules_dir(self.project_root)
 
         remappings = []

--- a/scripts/truffle_project.py
+++ b/scripts/truffle_project.py
@@ -31,8 +31,8 @@ class TruffleProject(project.Project):
     """A project that uses the truffle development environment to compile the
     project."""
 
-    def __init__(self, project_root, pretty_output):
-        super().__init__(project_root, pretty_output)
+    def __init__(self, project_root, json_output):
+        super().__init__(project_root, json_output)
         self.build_dir = self.project_root / pathlib.Path("build/contracts/")
 
     def compile_(self, compilation_output):

--- a/scripts/truffle_project.py
+++ b/scripts/truffle_project.py
@@ -43,6 +43,7 @@ class TruffleProject(project.Project):
                                                  stderr=subprocess.PIPE)
                 logging.info(output)
             except CalledProcessError as e:
+                logging.error("Error compiling Truffle project")
                 utils.handle_process_output_and_exit(e)
 
         self._merge_compiled_files(compilation_output)

--- a/scripts/truffle_project.py
+++ b/scripts/truffle_project.py
@@ -31,13 +31,19 @@ class TruffleProject(project.Project):
     """A project that uses the truffle development environment to compile the
     project."""
 
-    def __init__(self, project_root, json_output):
-        super().__init__(project_root, json_output)
+    def __init__(self, project_root, clargs):
+        super().__init__(project_root, clargs)
         self.build_dir = self.project_root / pathlib.Path("build/contracts/")
 
     def compile_(self, compilation_output):
         with utils.working_directory(self.project_root):
-            utils.run_cmd(["truffle", "compile"], loglevel=logging.INFO)
+            try:
+                output = subprocess.check_output(["truffle", "compile"],
+                                                 universal_newlines=True,
+                                                 stderr=subprocess.PIPE)
+                logging.info(output)
+            except CalledProcessError as e:
+                utils.handle_process_output_and_exit(e)
 
         self._merge_compiled_files(compilation_output)
 

--- a/scripts/truffle_project.py
+++ b/scripts/truffle_project.py
@@ -31,8 +31,8 @@ class TruffleProject(project.Project):
     """A project that uses the truffle development environment to compile the
     project."""
 
-    def __init__(self, project_root, clargs):
-        super().__init__(project_root, clargs)
+    def __init__(self, project_root, args):
+        super().__init__(project_root, args)
         self.build_dir = self.project_root / pathlib.Path("build/contracts/")
 
     def compile_(self, compilation_output):
@@ -40,7 +40,7 @@ class TruffleProject(project.Project):
             try:
                 output = subprocess.check_output(["truffle", "compile"],
                                                  universal_newlines=True,
-                                                 stderr=subprocess.PIPE)
+                                                 stderr=subprocess.STDOUT)
                 logging.info(output)
             except CalledProcessError as e:
                 logging.error("Error compiling Truffle project")

--- a/scripts/truffle_project.py
+++ b/scripts/truffle_project.py
@@ -28,7 +28,8 @@ from . import project
 
 
 class TruffleProject(project.Project):
-    """A project that uses the truffle development environment to compile the project."""
+    """A project that uses the truffle development environment to compile the
+    project."""
 
     def __init__(self, project_root, pretty_output):
         super().__init__(project_root, pretty_output)
@@ -36,20 +37,17 @@ class TruffleProject(project.Project):
 
     def compile_(self, compilation_output):
         with utils.working_directory(self.project_root):
-            try:
-                subprocess.check_output(["truffle", "compile"],
-                                        stderr=subprocess.STDOUT)
-            except subprocess.CalledProcessError as e:
-                logging.error("Error compiling truffle project.")
-                utils.handle_process_output_and_exit(e)
+            utils.run_cmd(["truffle", "compile"], loglevel=logging.INFO)
 
         self._merge_compiled_files(compilation_output)
 
     def _merge_compiled_files(self, compilation_output):
-        """Merges individual truffle files into an aggregate file for securify."""
+        """Merges individual truffle files into an aggregate file for
+        securify."""
         result = {}
         for entry in os.scandir(self.build_dir):
-            if entry.is_file() and entry.name.endswith(".json") and entry.name != "Migrations.json":
+            if entry.is_file() and entry.name.endswith(".json") and\
+                                   entry.name != "Migrations.json":
                 with open(entry) as file:
                     data = json.load(file)
                 contract_name = data["sourcePath"] + ":" + data["contractName"]

--- a/scripts/truffle_project.py
+++ b/scripts/truffle_project.py
@@ -41,8 +41,8 @@ class TruffleProject(project.Project):
                 output = subprocess.check_output(["truffle", "compile"],
                                                  universal_newlines=True,
                                                  stderr=subprocess.STDOUT)
-                logging.info(output)
-            except CalledProcessError as e:
+                logging.debug(output)
+            except subprocess.CalledProcessError as e:
                 logging.error("Error compiling Truffle project")
                 utils.handle_process_output_and_exit(e)
 
@@ -54,7 +54,7 @@ class TruffleProject(project.Project):
         result = {}
         for entry in os.scandir(self.build_dir):
             if entry.is_file() and entry.name.endswith(".json") and\
-                                   entry.name != "Migrations.json":
+                    entry.name != "Migrations.json":
                 with open(entry) as file:
                     data = json.load(file)
                 contract_name = data["sourcePath"] + ":" + data["contractName"]

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -22,7 +22,6 @@ import logging
 import os
 import re
 import sys
-import subprocess
 
 from solc.exceptions import SolcError
 import solc.install
@@ -90,37 +89,10 @@ def parse_sol_version(source):
     return DEFAULT_SOLC_VERSION
 
 
-def run_cmd(cmd, loglevel=logging.WARNING):
-    """Runs a command a prints output to console in realtime. If the command
-    fails, the standard error buffer is printed to console and the program
-    exits.
-
-    Args:
-        - cmd: a list of strings representing the command.
-        - loglevel: the log level at which the output from the command should
-          be logged.
-    """
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE,
-                            universal_newlines=True)
-    while True:
-        output = proc.stdout.readline()
-        if output == "" and proc.poll() is not None:
-            break
-        if output:
-            if output.endswith("\n"):
-                output = output[:-1]
-            logging.log(loglevel, output)
-
-    if proc.poll() != 0:
-        logging.error("Error running securify.")
-        utils.handle_process_output_and_exit(proc)
-
-
-def handle_process_output_and_exit(process):
-    """Processes stderr from a subprocess Popen object."""
-    if process.stderr:
-        logging.info(process.stderr.strip())
+def handle_process_output_and_exit(error):
+    """Processes stderr from a process error."""
+    if error.stderr:
+        logging.fatal(error.stderr.strip())
     sys.exit(1)
 
 

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -96,17 +96,6 @@ def handle_process_output_and_exit(error):
     sys.exit(1)
 
 
-def set_logger_level(level=None):
-    if level == "info":
-        log_level = logging.INFO
-    elif level == "error":
-        log_level = logging.ERROR
-    else:
-        log_level = logging.WARNING
-
-    logging.basicConfig(format="%(message)s", level=log_level)
-
-
 @contextlib.contextmanager
 def working_directory(path):
     prev_cwd = os.getcwd()

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -52,13 +52,14 @@ class SolidityCompilationException(SolcError):
 
 
 def version_to_tuple(v):
-    """Converts a version string into a tuple."""
+    """Converts a version string into a tuple.
+    """
     return tuple(map(int, v.split('.')))
 
 
 def find_node_modules_dir(directory):
-    """Returns the path to the node module directory contained in the
-    `directory` directory."""
+    """Returns the path of the node module folder contained in directory.
+    """
     for x in os.walk(directory):
         if os.path.isdir(os.path.join(x[0], 'node_modules')):
             return os.path.join(x[0], 'node_modules')
@@ -66,7 +67,8 @@ def find_node_modules_dir(directory):
 
 
 def parse_sol_version(source):
-    """Parses the solidity version from a contract using the pragma."""
+    """Parses the Solidity version from a contract using the pragma.
+    """
     with open(source, encoding='utf-8') as f:
         lines = f.readlines()
 
@@ -90,7 +92,8 @@ def parse_sol_version(source):
 
 
 def handle_process_output_and_exit(error):
-    """Processes stderr from a process error."""
+    """Processes stderr from a process error.
+    """
     if error.stdout:
         logging.fatal(error.stdout.strip())
     sys.exit(1)
@@ -98,6 +101,8 @@ def handle_process_output_and_exit(error):
 
 @contextlib.contextmanager
 def working_directory(path):
+    """Changes current directory to path.
+    """
     prev_cwd = os.getcwd()
     os.chdir(path)
     try:

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -91,8 +91,8 @@ def parse_sol_version(source):
 
 def handle_process_output_and_exit(error):
     """Processes stderr from a process error."""
-    if error.stderr:
-        logging.fatal(error.stderr.strip())
+    if error.stdout:
+        logging.fatal(error.stdout.strip())
     sys.exit(1)
 
 

--- a/src/main/java/ch/securify/CompilationHelpers.java
+++ b/src/main/java/ch/securify/CompilationHelpers.java
@@ -136,6 +136,7 @@ public class CompilationHelpers {
     }
 
     static SolidityResult getMappingsFromStatusFile(String livestatusfile, String map, byte[] contract) throws IOException {
+        System.out.println("  Obtaining source mapping for contract...");
         JsonObject jsonObject = new JsonParser().parse(readFile(livestatusfile)).getAsJsonObject();
         Set<Map.Entry<String, JsonElement>> results = jsonObject.get("patternResults").getAsJsonObject().entrySet();
 

--- a/src/main/java/ch/securify/CompilationHelpers.java
+++ b/src/main/java/ch/securify/CompilationHelpers.java
@@ -136,7 +136,6 @@ public class CompilationHelpers {
     }
 
     static SolidityResult getMappingsFromStatusFile(String livestatusfile, String map, byte[] contract) throws IOException {
-        System.out.println("  Obtaining source mapping for contract...");
         JsonObject jsonObject = new JsonParser().parse(readFile(livestatusfile)).getAsJsonObject();
         Set<Map.Entry<String, JsonElement>> results = jsonObject.get("patternResults").getAsJsonObject().entrySet();
 

--- a/src/main/java/ch/securify/Main.java
+++ b/src/main/java/ch/securify/Main.java
@@ -77,8 +77,8 @@ public class Main {
         @Parameter(names = {"--progress"}, description = "show progress when contracts are being processed")
         private boolean progress;
 
-        @Parameter(names = {"--pretty"}, description = "display pretty 'clang style' output")
-        private boolean prettyOutput;
+        @Parameter(names = {"--no-output"}, description = "supress pretty output")
+        private boolean suppressOutput;
     }
 
     private static List<AbstractPattern> patterns;
@@ -234,10 +234,10 @@ public class Main {
                 } catch (Exception ex) {
                     throw new RuntimeException(ex);
                 }
-                if (args.prettyOutput) {
+                if (!args.suppressOutput) {
                     OutputGenerator.print(allContractsResults);
                 }
-            } else if (args.prettyOutput) {
+            } else if (!args.suppressOutput) {
                 OutputGenerator.print(allContractsResults);
             } else {
                 gson.toJson(allContractsResults, System.out);

--- a/src/main/java/ch/securify/Main.java
+++ b/src/main/java/ch/securify/Main.java
@@ -85,8 +85,7 @@ public class Main {
 
     private static List<AbstractPattern> patterns;
     private static ContractResult contractResult;
-    private static boolean DEBUG = false;
-    private static PrintStream log = DEBUG ? System.out : new DevNullPrintStream();
+    private static PrintStream log = new DevNullPrintStream();
     private static PrintStream progressPrinter = System.out;
     private static Args args;
 

--- a/src/main/java/ch/securify/Main.java
+++ b/src/main/java/ch/securify/Main.java
@@ -105,8 +105,7 @@ public class Main {
         TreeMap<String, SolidityResult> allContractResults = new TreeMap<>();
         for (Map.Entry<String, JsonElement> elt : entries) {
             initPatterns(args);
-            log.println("Processing contract:");
-            log.println(elt.getKey());
+            System.out.println("Processing contract: " + elt.getKey());
 
             String bin = elt.getValue().getAsJsonObject().get("bin-runtime").getAsString();
             String map = elt.getValue().getAsJsonObject().get("srcmap-runtime").getAsString();
@@ -263,24 +262,24 @@ public class Main {
     public static List<Instruction> decompileContract(byte[] binary) {
         List<Instruction> instructions;
         try {
-            log.println("Attempt to decompile the contract with methods...");
+            System.out.println("  Attempt to decompile the contract with methods...");
             instructions = Decompiler.decompile(binary, log);
 
-            log.println("Success. Inlining methods...");
+            System.out.println("  Success. Inlining methods...");
             instructions = MethodInliner.inline(instructions, log);
         } catch (Exception e1) {
             log.println(e1.getMessage());
-            log.println("Failed to decompile methods. Attempt to decompile the contract without identifying methods...");
+            System.out.println("  Failed to decompile methods. Attempt to decompile the contract without identifying methods...");
 
             try {
                 instructions = DecompilerFallback.decompile(binary, log);
             } catch (Exception e2) {
-                log.println("Decompilation failed.");
+                System.out.println("  Decompilation failed.");
                 throw e2;
             }
         }
 
-        log.println("Propagating constants...");
+        System.out.println("  Propagating constants...");
         ConstantPropagation.propagate(instructions);
 
         log.println();


### PR DESCRIPTION
Securify now provides progress information to the user. Moreover, the docker now provides more useful verbose and quiet flags to provide information about the compilation stages and suppress most output respectively.

On top of that, the `--pretty` flag is now default. A `--no-output` flag was added to the Java executable in case the user is only interested in the JSON output to file, and wants to suppress the pretty output.

The docker version now supports a `--json` flag instead of the `--pretty` flag if the user wants to get the JSON output instead.