### PR TITLE
fixed logging for verbose and quiet flags in wrapper

### DIFF
--- a/scripts/controller.py
+++ b/scripts/controller.py
@@ -57,14 +57,14 @@ class Controller:
             self._project = solc_project.SolcProject(
                 self.args.project, self.args)
 
-        logging.basicConfig(format="%(message)s")
-
         if self.args.verbose:
-            logging.basicConfig(level=logging.DEBUG)
+            level = logging.DEBUG
         elif self.args.quiet:
-            logging.basicConfig(level=logging.WARNING)
+            level = logging.WARNING
         else:
-            logging.basicConfig(level=logging.INFO)
+            level = logging.INFO
+
+        logging.basicConfig(level=level, format="%(message)s")
 
     def compile_and_report(self):
         """Executes securify and returns violations and warnings.


### PR DESCRIPTION
Previously adding verbosity flags did not affect the wrapper log level.

Only a single call to `basicConfig` is accepted unless a handler is changed in the `logging` module. Reducing logging level and format to a single call to `basicConfig` fixes the issue. 