### PR TITLE
Add argument option to specify solc manually.

### DIFF
--- a/src/main/java/ch/securify/CompilationHelpers.java
+++ b/src/main/java/ch/securify/CompilationHelpers.java
@@ -94,8 +94,8 @@ public class CompilationHelpers {
         return new String(encoded, Charset.defaultCharset());
     }
 
-    static JsonObject compileContracts(String filesol) throws IOException, InterruptedException, RuntimeException {
-        ProcessBuilder p = new ProcessBuilder("solc", "--combined-json", "abi,ast,bin-runtime,srcmap-runtime", filesol);
+    static JsonObject compileContracts(String solc, String filesol) throws IOException, InterruptedException, RuntimeException {
+        ProcessBuilder p = new ProcessBuilder(solc, "--combined-json", "abi,ast,bin-runtime,srcmap-runtime", filesol);
 
         File f = File.createTempFile("securify_compilation_", ".json");
         f.deleteOnExit();

--- a/src/main/java/ch/securify/Main.java
+++ b/src/main/java/ch/securify/Main.java
@@ -83,8 +83,11 @@ public class Main {
         @Parameter(names = {"--json"}, description = "provide JSON output to console")
         private boolean jsonOutput;
 
-        @Parameter(names = {"--descriptions"}, description= "add descriptions to the JSON output")
+        @Parameter(names = {"--descriptions"}, description = "add descriptions to the JSON output")
         private boolean descriptions;
+
+        @Parameter(names = {"--solc-path"}, description = "manually specify the path for  the solc binary")
+        private String solcPath = "solc";
     }
 
     private static List<AbstractPattern> patterns;
@@ -95,7 +98,7 @@ public class Main {
 
 
     public static TreeMap<String, SolidityResult> processSolidityFile(String filesol, String livestatusfile) throws IOException, InterruptedException {
-        JsonObject compilationOutput = CompilationHelpers.compileContracts(filesol);
+        JsonObject compilationOutput = CompilationHelpers.compileContracts(args.solcPath, filesol);
 
         return processCompilationOutput(compilationOutput, livestatusfile);
     }


### PR DESCRIPTION
Closes #76.
Adds the possibility to specify different version compilers other than the one provided by the system installation.
```bash
(patch-solc-path*) $ java -jar build/libs/securify-0.1.jar -fs ~/zeppelin/contracts/example.sol
/home/matt/zeppelin/contracts/example:1:1: Error: Source file requires different compiler version (current compiler is 0.5.0+commit.1d4f565a.Linux.g++ - note that nightly builds are considered to be strictly less than the released version
pragma solidity ^0.4.25;
^----------------------^
/home/matt/zeppelin/contracts/example.sol:2:1: Error: Unsupported experimental feature name.
pragma experimental "v0.5.0";
^---------------------------^
Exception in thread "main" java.lang.RuntimeException
        at ch.securify.CompilationHelpers.compileContracts(CompilationHelpers.java:112)
        at ch.securify.Main.processSolidityFile(Main.java:101)
        at ch.securify.Main.main(Main.java:242)
```
This is because the current contract uses a lower version of solc and the compiler installed is ahead.
```bash
(patch-solc-path*) $ solc --version                                                                                               
solc, the solidity compiler commandline interface
Version: 0.5.0+commit.1d4f565a.Linux.g++
```

Now with a downloaded statically solc 0.4.25
```bash
(patch-solc-path*) $ ./solc-static-linux --version                                                                                
solc, the solidity compiler commandline interface
Version: 0.4.25+commit.59dbf8f1.Linux.g++
```

Trying again with the new parameter --solc-path:
```bash
(patch-solc-path*) $ java -jar build/libs/securify-0.1.jar --solc-path ./solc-static-linux -fs ~/zeppelin/contracts/Example.sol
Processing contract: /home/matt/zeppelin/contracts/Example.sol:SarasaMath
  Attempt to decompile the contract with methods...
  Failed to decompile methods. Attempt to decompile the contract without identifying methods...
  Propagating constants...
  Verifying patterns...
Warning for LockedEther in contract 'SarasaMath':
    |
    |
  > |library SarasaMath {
    |    /**
    |    * @dev Returns the absolute positive of the int256 as uint256
  at /home/matt/zeppelin/contracts/Example.sol(10)

```

