### PR TITLE
use timeout from Java instead of binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ubuntu:18.04
+FROM ubuntu:latest
 
-LABEL maintainer="contact@securify.ch"
+LABEL maintainer="contact@chainsecurity.com"
 
 # install basic packages
 RUN apt-get update && apt-get install -y\
@@ -20,9 +20,8 @@ RUN apt-get update &&\
         wget\
         gdebi
 
-RUN mkdir /souffle
-RUN wget -P /souffle/ https://github.com/souffle-lang/souffle/releases/download/1.4.0/souffle_1.4.0-1_amd64.deb &&\
-        gdebi --n /souffle/souffle_1.4.0-1_amd64.deb
+RUN wget https://github.com/souffle-lang/souffle/releases/download/1.4.0/souffle_1.4.0-1_amd64.deb -O /tmp/souffle.deb &&\
+        gdebi --n /tmp/souffle.deb
 
 # install java and pip
 RUN apt-get update && apt-get -y install\
@@ -32,8 +31,7 @@ RUN apt-get update && apt-get -y install\
 COPY requirements.txt /tmp/
 RUN pip3 install --user -r /tmp/requirements.txt
 
-RUN mkdir /isolc
-COPY scripts/isolc/* /isolc/
+COPY scripts/isolc/ /isolc/
 RUN cd / && python3 -m isolc.install_solc
 
 # install truffle for project compilation
@@ -59,5 +57,5 @@ RUN ./gradlew jar
 # Solidity example
 COPY src/test/resources/solidity/transaction-reordering.sol /project/example.sol
 
-# run_securify.py allows arguments to be passed (e.g. "--truffle").
+# this Python script allows arguments to be passed (e.g. "--truffle").
 ENTRYPOINT ["python3", "docker_run_securify.py", "-p", "/project"]

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ contribute developing new patterns please get in touch through our
 * A `solc` binary is required to be able to use Solidity file as input.
   Securify assumes that the right version is installed for the given file.
   `solc` is available [here](https://github.com/ethereum/solidity/releases).
-* Linux users must have the [timeout](https://linux.die.net/man/1/timeout) command, OS X users must have the `gtimeout` command, which can be install with `brew install coreutils`.
 
 ### Use
 

--- a/src/main/java/ch/securify/SolidityResult.java
+++ b/src/main/java/ch/securify/SolidityResult.java
@@ -20,7 +20,6 @@ class SolidityResult {
      */
     static void setPatternDescriptions(List<AbstractPattern> patterns) {
         // only allow initialization once
-        assert patternDescriptions == null;
         patternDescriptions = new LinkedList<>();
         patterns.forEach(pattern -> patternDescriptions.add(pattern.getDescription()));
     }

--- a/src/main/java/ch/securify/analysis/AbstractDataflow.java
+++ b/src/main/java/ch/securify/analysis/AbstractDataflow.java
@@ -277,9 +277,9 @@ public abstract class AbstractDataflow {
             }
         }
 
-        proc.waitFor(timeout, TimeUnit.SECONDS);
-
-        if (proc.exitValue() != 0) {
+        if (!proc.waitFor(timeout, TimeUnit.SECONDS) || proc.exitValue() != 0) {
+            proc.destroyForcibly();
+            proc.waitFor();
             throw new IOException(String.join(" ", command));
         }
     }

--- a/test.py
+++ b/test.py
@@ -127,7 +127,10 @@ def test_securify_analysis(c_file, json_output, memory=8, overwrite=False):
 
         if overwrite:
             print('Overwriting.')
-            shutil.copy(output, json_output)
+            with open(json_output, 'w') as fso, open(output) as fsi:
+                content = json.load(fsi)
+                json.dump(content, fso, sort_keys=True, indent=2)
+
             return
 
         with open(output) as fsc:

--- a/test.py
+++ b/test.py
@@ -111,6 +111,8 @@ def test_securify_analysis(c_file, json_output, memory=8, overwrite=False):
         output = Path(tmpdir) / 'sec_output.json'
 
         cmd = ['java',
+               # enable assertions
+               '-ea',
                f'-Xmx{memory}G',
                '-jar', 'build/libs/securify-0.1.jar',
                '-fs', c_file,


### PR DESCRIPTION
This *seems* to fix #15, for some reason.

I'm currently making other changes to avoid using binaries (e.g., `rm`), so no need to review this now.